### PR TITLE
Link macOS CoreAudio frameworks in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,12 @@ target_link_libraries(gaga PRIVATE Threads::Threads)
 
 if(WIN32)
     target_link_libraries(gaga PRIVATE avrt ole32 winmm)
+elseif(APPLE)
+    target_link_libraries(gaga PRIVATE
+        "-framework AudioToolbox"
+        "-framework CoreAudio"
+        "-framework CoreFoundation"
+    )
 elseif(UNIX AND NOT APPLE)
     target_link_libraries(gaga PRIVATE dl m)
 endif()


### PR DESCRIPTION
### Motivation
- Fix the macOS CI build failure by explicitly linking the system audio frameworks required by miniaudio/CoreAudio on macOS.

### Description
- Add an `APPLE` branch in `CMakeLists.txt` that links `AudioToolbox`, `CoreAudio`, and `CoreFoundation` for the `gaga` target using `target_link_libraries`.

### Testing
- Executed `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON && cmake --build build --parallel && ctest --test-dir build --output-on-failure`, which failed during `FetchContent` when cloning `https://github.com/mackron/miniaudio.git` due to a network tunnel `CONNECT ... 403`, so the full build and tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac66f247d883309d1fbaf690a1bdd3)