### PR TITLE
Fix macOS libc++ build failure from atomic<shared_ptr> usage

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -80,7 +80,10 @@ void audio_callback(ma_device* device, void* output, const void* input, ma_uint3
                 continue;
             }
 
-            auto pending = engine->pending_snapshot.exchange(std::shared_ptr<const PatternSnapshot>{});
+            auto pending = std::atomic_exchange_explicit(
+                &engine->pending_snapshot,
+                std::shared_ptr<const PatternSnapshot>{},
+                std::memory_order_acq_rel);
             if (pending) {
                 engine->active_snapshot = std::move(pending);
             }
@@ -187,7 +190,7 @@ bool pop_runtime_event(RuntimeEventQueue& queue, RuntimeEvent& event) {
 }
 
 void store_pending_snapshot(AudioEngine& engine, std::shared_ptr<const PatternSnapshot> snapshot) {
-    engine.pending_snapshot.store(std::move(snapshot));
+    std::atomic_store_explicit(&engine.pending_snapshot, std::move(snapshot), std::memory_order_release);
 }
 
 }  // namespace gaga

--- a/src/audio.hpp
+++ b/src/audio.hpp
@@ -47,7 +47,7 @@ struct RuntimeEventQueue {
 struct AudioEngine {
     ma_device* device_handle = nullptr;
     std::shared_ptr<const PatternSnapshot> active_snapshot;
-    std::atomic<std::shared_ptr<const PatternSnapshot>> pending_snapshot;
+    std::shared_ptr<const PatternSnapshot> pending_snapshot;
     RuntimeEventQueue runtime_events;
     TransportState transport;
     SynthVoice voice;


### PR DESCRIPTION
### Motivation
- Xcode 16.4's libc++ rejects `std::atomic<T>` for types that are not trivially copyable, which caused build errors when using `std::atomic<std::shared_ptr<const PatternSnapshot>>`.
- The goal is to preserve lock-free snapshot handoff semantics while making the code portable on macOS libc++.

### Description
- Replace the `AudioEngine` member `std::atomic<std::shared_ptr<const PatternSnapshot>> pending_snapshot` with a plain `std::shared_ptr<const PatternSnapshot>` in `src/audio.hpp`.
- Use the free atomic shared_ptr operations to perform atomic handoff: `std::atomic_exchange_explicit(&engine->pending_snapshot, std::shared_ptr<const PatternSnapshot>{}, std::memory_order_acq_rel)` when consuming a pending snapshot in the audio callback, and `std::atomic_store_explicit(&engine.pending_snapshot, std::move(snapshot), std::memory_order_release)` in `store_pending_snapshot` in `src/audio.cpp`.
- Changes are localized to `src/audio.hpp` and `src/audio.cpp` and preserve the intended publish/consume semantics without relying on `std::atomic<T>` specialization for `shared_ptr`.

### Testing
- Attempted to run `cmake -S . -B build && cmake --build build --parallel` to validate the build, but the build was aborted because `FetchContent` could not clone `https://github.com/mackron/miniaudio.git` due to network restrictions (CONNECT tunnel 403), so full build verification could not complete.
- No automated unit tests were run in this environment due to the network-blocked dependency fetch preventing a complete build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac68484d7c8330847626ef2d39d7e7)